### PR TITLE
Add custom CSS for shiny bikes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -17,6 +17,13 @@ const BATTERY_STYLES: [number, string, string][] = [
 // API base.
 const STATION_LIST_URL = "https://publibike-api.delroth.net/v1/public/stations";
 
+// List of Shiny (Special Edition) bikes. Crowdsourced list.
+const SHINY_BIKES = [
+    104951,
+    503674,
+    504027,
+];
+
 enum BikeType { Bike = 1, EBike = 2 }
 
 interface LatLon {
@@ -144,11 +151,6 @@ function FormatDistance(meters: number): string {
     }
 }
 
-function FormatEBike(eb: EBike): string {
-    const bat = eb.battery == -1 ? '' : ` (${eb.battery}%)`;
-    return `${eb.name}${bat}`;
-}
-
 (async function () {
     const $status = document.getElementById('status');
     const $station_table = document.getElementById('stations-table');
@@ -250,11 +252,23 @@ function FormatEBike(eb: EBike): string {
                 const $best_ebikes = document.createElement('td');
                 $best_ebikes.colSpan = 5;
                 shown_ebikes
-                    .map(FormatEBike)
-                    .forEach(text => {
+                    .forEach(ebike => {
                         const $span = document.createElement('span');
-                        $span.textContent = text;
-                        $span.className = "battery-lvl";
+                        $span.className = "battery-lvl"
+
+                        const $name = document.createElement('span');
+                        $name.textContent = ebike.name;
+                        if (SHINY_BIKES.includes(parseInt(ebike.name))) {
+                            $name.classList.add("text-shiny");
+                        }
+                        $span.appendChild($name);
+
+                        if (ebike.battery != -1) {
+                            const $bat =  document.createElement('span');
+                            $bat.textContent = ` (${ebike.battery}%)`;
+                            $span.appendChild($bat);
+                        }
+
                         $best_ebikes.appendChild($span);
                     });
                 $battery_row.appendChild($best_ebikes);

--- a/index.html
+++ b/index.html
@@ -138,6 +138,27 @@
         .bat-zero {
             color: #bd005e;
         }
+
+        .text-shiny {
+            padding: 3px 4px;
+            font-weight: bold;
+            background-color:         goldenrod;
+            background-image: linear-gradient(
+                to right,
+                transparent, rgba(238,232,170, 0.8), transparent
+                    );
+            background-size: 200% 100%;
+            animation: shinyEffect 3s linear infinite;
+            border-radius: 3px;
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        @keyframes shinyEffect {
+            0% { background-position: -100% center; }
+            50% { background-position: 100% center; }
+            100% { background-position: -100% center; }
+        }
     </style>
 </head>
 


### PR DESCRIPTION
Some bikes are shiny. It's good to be notified when a nearby station has a shiny bike, so you can be sure to grab it.

![image](https://github.com/user-attachments/assets/5ea9b68c-d922-4104-a047-0ac64216e559)

![image](https://github.com/user-attachments/assets/b2cc7f9a-fcfc-4882-a2cd-932e221653fc)
